### PR TITLE
Fix incorrect NULL check on strtoul() output parameter

### DIFF
--- a/opendkim/reputation.c
+++ b/opendkim/reputation.c
@@ -413,7 +413,8 @@ dkimf_rep_check(DKIMF_REP rep, DKIM_SIGINFO *sig, _Bool spam,
 			buf[req[fields - 1].dbdata_buflen] = '\0';
 
 			reps.reps_limit = (unsigned long) (ceil((double) strtoul(buf, &p, 10) / (double) rep->rep_factor) + 1.);
-			if (p != NULL && *p != '\0')
+			/* p is always non-NULL (strtoul sets it to point into buf), so check for trailing chars */
+			if (p == buf || *p != '\0')
 			{
 				if (errbuf != NULL)
 				{


### PR DESCRIPTION
The variable p is a char* output parameter from strtoul() which always points to a character in the input string (or the end). It can never be NULL, making the check 'p != NULL' redundant and incorrect.

Fix by removing the redundant NULL check and instead checking if p == buf (no conversion occurred) or if there are trailing non-numeric characters (*p != '\0').

This ensures proper validation of the strtoul() conversion result.