### PR TITLE
Fix buffer overflow in ut_generate() when truncating vlist

### DIFF
--- a/libut/ut.c
+++ b/libut/ut.c
@@ -747,7 +747,19 @@ ut_generate(URITEMP ut, const char *template, char *out, size_t outlen)
 			}
 
 			vlist = strdup(p);
-			vlist[vlistlen - 1] = '\0';
+			if (vlist == NULL)
+			{
+				error = UT_ERROR_MALFORMED;
+				continue;
+			}
+			/* Recalculate length from current p position to closing brace */
+			/* to avoid buffer overflow from using stale vlistlen value */
+			if (eb > p)
+			{
+				size_t actual_len = eb - p;
+				if (actual_len < strlen(vlist))
+					vlist[actual_len] = '\0';
+			}
 
 			for (v = strtok_r(vlist, ",", &ctx);
 			     v != NULL;


### PR DESCRIPTION
The vlistlen variable was calculated before pointer p was incremented multiple times in the switch statement. When strdup(p) was called, the actual string length was shorter than vlistlen, causing a potential buffer overflow when accessing vlist[vlistlen - 1].

Fix by recalculating the actual length from the current p position to the closing brace (eb) after all pointer increments, ensuring we never access beyond the allocated string bounds.

Also add NULL check for strdup() failure case.

Fixes buffer overflow vulnerability in URI template processing.