### PR TITLE
Prevent integer underflow when truncating vlist string

### DIFF
--- a/libut/ut.c
+++ b/libut/ut.c
@@ -747,7 +747,11 @@ ut_generate(URITEMP ut, const char *template, char *out, size_t outlen)
 			}
 
 			vlist = strdup(p);
-			vlist[vlistlen - 1] = '\0';
+			/* Prevent integer underflow: ensure vlistlen > 0 before subtracting */
+			if (vlistlen > 0 && vlistlen <= strlen(vlist))
+			{
+				vlist[vlistlen - 1] = '\0';
+			}
 
 			for (v = strtok_r(vlist, ",", &ctx);
 			     v != NULL;


### PR DESCRIPTION
The code accesses vlist[vlistlen - 1] without checking if vlistlen > 0. If vlistlen is 0 (due to decrements in the switch statement), then vlistlen - 1 would underflow to SIZE_MAX (since vlistlen is size_t), causing a buffer overflow.

Fix by checking that vlistlen > 0 and that vlistlen is within the actual string bounds before accessing vlist[vlistlen - 1]. This prevents both integer underflow and buffer overflow vulnerabilities.