### PR TITLE
Add bounds check before accessing percent-encoded characters

### DIFF
--- a/libut/ut.c
+++ b/libut/ut.c
@@ -624,7 +624,8 @@ ut_generate(URITEMP ut, const char *template, char *out, size_t outlen)
 			olen++;
 			continue;
 		}
-		else if (ut_pct_encoded(p))
+		/* Check bounds before calling ut_pct_encoded to avoid OOB access */
+		else if (*p == '%' && *(p + 1) != '\0' && *(p + 2) != '\0' && ut_pct_encoded(p))
 		{
 			char c;
 


### PR DESCRIPTION
The ut_pct_encoded() function accesses *(p+1) and *(p+2) without verifying that these positions are within the string bounds. If p is near the end of the string, this could cause an out-of-bounds memory access.

Fix by checking that *(p+1) and *(p+2) are not null terminators before calling ut_pct_encoded(), preventing potential buffer over-read vulnerabilities.

This ensures we never access memory beyond the string when processing percent-encoded sequences in URI templates.