### PR TITLE
Fix missing null termination in dkim_get_sigsubstring()

### DIFF
--- a/libopendkim/dkim.c
+++ b/libopendkim/dkim.c
@@ -8794,9 +8794,11 @@ dkim_get_sigsubstring(DKIM *dkim, DKIM_SIGINFO *sig, char *buf, size_t *buflen)
 		return DKIM_STAT_SYNTAX;
 
 	minlen = MIN(*buflen, dkim->dkim_minsiglen);
+	/* Ensure we always have room for null terminator */
+	if (minlen >= *buflen)
+		minlen = *buflen - 1;
 	strncpy(buf, b1, minlen);
-	if (minlen < *buflen)
-		buf[minlen] = '\0';
+	buf[minlen] = '\0';
 	*buflen = minlen;
 
 	return DKIM_STAT_OK;


### PR DESCRIPTION
When minlen equals *buflen, the buffer is exactly full and strncpy() doesn't null-terminate. The existing check 'if (minlen < *buflen)' prevents adding a null terminator in this case, leaving the buffer potentially non-null-terminated.

Fix by ensuring we always reserve at least one byte for the null terminator. If minlen >= *buflen, reduce it to *buflen - 1 before copying, then always add the null terminator. This guarantees the buffer is always properly null-terminated.